### PR TITLE
Correct default certname in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ puppet_enterprise::master::puppetserver::puppet_admin_certs:
   - "%{::clientcert}"
 ```
 
-This hiera key will allow the certificate on each compile master to access it's own admin API where as by default only the pe-internal-dashboard cert can access. 
+This hiera key will allow the certificate on each compile master to access it's own admin API where as by default only the pe-internal-classifier cert can access. 
 
 # To Use This Module
 


### PR DESCRIPTION
By default, only the `pe-internal-classifier` cert has access to the
Puppet Server admin API.
