### PR TITLE
Reduce curl noise

### DIFF
--- a/templates/curl_to_flush_jruby_pool.erb
+++ b/templates/curl_to_flush_jruby_pool.erb
@@ -1,1 +1,1 @@
-curl -X DELETE --cacert /etc/puppetlabs/puppet/ssl/certs/ca.pem --cert /etc/puppetlabs/puppet/ssl/certs/<%= @clientcert %>.pem --key /etc/puppetlabs/puppet/ssl/private_keys/<%= @clientcert %>.pem https://<%= @fqdn %>:8140/puppet-admin-api/v1/jruby-pool
+curl -sS -X DELETE --cacert /etc/puppetlabs/puppet/ssl/certs/ca.pem --cert /etc/puppetlabs/puppet/ssl/certs/<%= @clientcert %>.pem --key /etc/puppetlabs/puppet/ssl/private_keys/<%= @clientcert %>.pem https://<%= @fqdn %>:8140/puppet-admin-api/v1/jruby-pool


### PR DESCRIPTION
This patch adds the `-s` flag to the curl invocation which put it into silent
mode in order to cut down on the noise generated by cron. The `-S` flag is also
added so that curl will log some noise if an error happens.
